### PR TITLE
use unique replies to correlate polls and replies

### DIFF
--- a/surveyor/collector_statz.go
+++ b/surveyor/collector_statz.go
@@ -276,6 +276,7 @@ func (sc *StatzCollector) poll() error {
 	select {
 	case <-sc.doneCh:
 	case <-time.After(sc.pollTimeout):
+		log.Printf("Poll timeout after %v while waiting for %d responses\n", sc.pollTimeout, sc.numServers)
 	}
 
 	sc.Lock()


### PR DESCRIPTION
This creates a wildcard subscribe which allow us to key the reply
to topic with a per poll key, we then check that replies received
is part of the current poll, it's a small improvement but should
make things a bit more robust and consistent

Also make the key used for tracking servers a bit more robust
and remove a unused prometheus description