### PR TITLE
block concurrent scrapes

### DIFF
--- a/surveyor/collector_statz.go
+++ b/surveyor/collector_statz.go
@@ -271,6 +271,13 @@ func (sc *StatzCollector) poll() error {
 	}
 	sc.Unlock()
 
+	// not all error paths clean this up, so this way might be easier
+	defer func() {
+		sc.Lock()
+		sc.polling = false
+		sc.Unlock()
+	}()
+
 	// fail fast if we aren't connected to return a nats down (nats_up=0) to
 	// Prometheus
 	if sc.nc.IsConnected() == false {

--- a/surveyor/collector_statz.go
+++ b/surveyor/collector_statz.go
@@ -220,6 +220,14 @@ func NewStatzCollector(nc *nats.Conn, numServers int, pollTimeout time.Duration)
 	return sc
 }
 
+// Polling determines if the collector is in a polling cycle
+func (sc *StatzCollector) Polling() bool {
+	sc.Lock()
+	defer sc.Unlock()
+
+	return sc.polling
+}
+
 func (sc *StatzCollector) handleResponse(msg *nats.Msg) {
 	m := &server.ServerStatsMsg{}
 	if err := json.Unmarshal(msg.Data, m); err != nil {

--- a/surveyor/surveyor.go
+++ b/surveyor/surveyor.go
@@ -214,8 +214,6 @@ func (s *Surveyor) isValidUserPass(user, password string) bool {
 func (s *Surveyor) httpAuthMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
 		if s.opts.HTTPUser != "" {
-			log.Printf("auth is disabled\n")
-
 			auth := strings.SplitN(r.Header.Get("Authorization"), " ", 2)
 			if len(auth) != 2 || auth[0] != "Basic" {
 				http.Error(rw, "authorization failed", http.StatusUnauthorized)

--- a/surveyor/surveyor_test.go
+++ b/surveyor/surveyor_test.go
@@ -143,25 +143,24 @@ func TestSurveyor_Basic(t *testing.T) {
 	}
 
 	// check for labels
-	if strings.Contains(output, "nats_server_host") == false {
-		t.Fatalf("invalid output:  %v\n", err)
+	if strings.Contains(output, "server_name") == false {
+		t.Fatalf("invalid output:  %v\n", output)
 	}
-	if strings.Contains(output, "nats_server_cluster") == false {
-		t.Fatalf("invalid output:  %v\n", err)
+	if strings.Contains(output, "server_cluster") == false {
+		t.Fatalf("invalid output:  %v\n", output)
 	}
-	if strings.Contains(output, "nats_server_id") == false {
-		t.Fatalf("invalid output:  %v\n", err)
+	if strings.Contains(output, "server_id") == false {
+		t.Fatalf("invalid output:  %v\n", output)
 	}
-	if strings.Contains(output, "nats_server_gateway_name") == false {
-		t.Fatalf("invalid output:  %v\n", err)
+	if strings.Contains(output, "server_gateway_name") == false {
+		t.Fatalf("invalid output:  %v\n", output)
 	}
-	if strings.Contains(output, "nats_server_gateway_id") == false {
-		t.Fatalf("invalid output:  %v\n", err)
+	if strings.Contains(output, "server_gateway_id") == false {
+		t.Fatalf("invalid output:  %v\n", output)
 	}
-	if strings.Contains(output, "nats_server_route_id") == false {
-		t.Fatalf("invalid output:  %v\n", err)
+	if strings.Contains(output, "server_route_id") == false {
+		t.Fatalf("invalid output:  %v\n", output)
 	}
-	s.Stop()
 }
 
 func TestSurveyor_Reconnect(t *testing.T) {
@@ -200,7 +199,7 @@ func TestSurveyor_Reconnect(t *testing.T) {
 		time.Sleep(1 * time.Second)
 	}
 	if err != nil {
-		t.Fatalf("Retries failed.")
+		t.Fatalf("Retries failed: %v.", err)
 	}
 	if strings.Contains(output, "nats_up 1") == false {
 		t.Fatalf("output did not contain nats-up 1")
@@ -329,5 +328,29 @@ func TestSurveyor_MissingResponses(t *testing.T) {
 	_, err = pollAndCheck(t, defaultSurveyorURL, "nats_core_mem_bytes")
 	if err != nil {
 		t.Fatalf("poll error:  %v\n", err)
+	}
+}
+
+func TestSurveyor_ConcurrentBlock(t *testing.T) {
+	sc := st.NewSuperCluster(t)
+	defer sc.Shutdown()
+
+	s, err := NewSurveyor(getTestOptions())
+	if err != nil {
+		t.Fatalf("couldn't create surveyor: %v", err)
+	}
+
+	if err = s.Start(); err != nil {
+		t.Fatalf("start error: %v", err)
+	}
+
+	s.statzC.polling = true
+	_, err = pollAndCheck(t, defaultSurveyorURL, "nats_core_mem_bytes")
+	if err == nil {
+		t.Fatalf("Expected an error but none were encountered")
+	}
+
+	if err.Error() != "expected a 200 response, got 503" {
+		t.Fatalf("Expected 503 error but got: %v", err)
 	}
 }


### PR DESCRIPTION
The design of this is not safe for multi threaded use, concurrent
access will publish concurrent pings and so we will get 2 sets
of replies - however only 1 polling boolean exist so this will
always confuse things - leading to logs about late replies etc

This will make concurrent polls just fail which is better than
give weird stats